### PR TITLE
Update _version and _release to respect skipping a version

### DIFF
--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -82,12 +82,12 @@ jobs:
     needs:
       - version
       - test-e2e
+    if: ${{ needs.version.outputs.is-release }} == 'true'
     permissions:
       contents: write
       packages: write
     uses: ./.github/workflows/_release.yml
     with:
-      is-release: true
       version: ${{ needs.version.outputs.version }}
 
 
@@ -95,6 +95,7 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: [release]
+    environment: staging
     steps:
       - run: echo "Automatically deploy to staging"
 

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -6,9 +6,6 @@ run-name: Release ${{ inputs.version }}
 on:
   workflow_call:
     inputs:
-      is-release:
-        type: boolean
-        required: true
       version:
         type: string
         required: true
@@ -28,7 +25,6 @@ jobs:
           fetch-depth: 0
 
       - name: Create Tag
-        if: ${{ ! inputs.is-release }}
         run: |
           git config --local user.email "<>"
           git config --local user.name "DevOps Bot"
@@ -37,7 +33,6 @@ jobs:
           git push origin v${{ inputs.version }}
 
       - name: Create release
-        if: ${{ inputs.is-release }}
         uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e  # v1.12.0
         with:
           commit: ${{ github.sha }}

--- a/.github/workflows/_version.yml
+++ b/.github/workflows/_version.yml
@@ -5,16 +5,16 @@ run-name: Calculate Version
 on:
   workflow_call:
     inputs:
-      is-release:
-        type: boolean
-        required: true
       pull-request-number:
         type: string
         required: true
     outputs:
       version:
-        description: "version to be built"
+        description: "calculated version"
         value: ${{ jobs.version.outputs.version }}
+      is-release:
+        description: "if version changed"
+        value: ${{ jobs.version.outputs.is-release }}
 
 jobs:
   version:
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.calculate.outputs.version }}
+      is-release: ${{ steps.calculate.outputs.is-release}}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
@@ -29,7 +30,6 @@ jobs:
           fetch-depth: 0
 
       - name: Get version bump type
-        if: ${{ inputs.is-release }}
         id: bump-type
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
           latest_tag_version=$(git tag --sort=committerdate --list | tail -1)
           latest_version=${latest_tag_version:1}  # remove 'v' from tag version
 
-          if [[ "${{ inputs.is-release }}" == "true" ]]; then
+          if [[ "${{ steps.bump-type.outputs.type }}" != "skip" ]]; then
             latest_major_version=$(echo $latest_version | cut -d "." -f 1)
             latest_minor_version=$(echo $latest_version | cut -d "." -f 2)
             latest_patch_version=$(echo $latest_version | cut -d "." -f 3)
@@ -85,6 +85,8 @@ jobs:
 
             echo "Next Version: $next_version"
             echo "version=$next_version" >> $GITHUB_OUTPUT
+            echo "is-release=true" >> $GITHUB_OUTPUT
           else
             echo "version=$latest_version+${{ inputs.pull-request-number }}" >> $GITHUB_OUTPUT
+            echo "is-release=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Stop trying to create a GitHub Release on every merge to `main`